### PR TITLE
Move load_config kitten into kitty-control subdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🐞 Fixed
 
 - Moved `read_config.py` kitten from `~/.config/kitty/` to `~/.config/kitty/kitty-control/`
+- Link `~/.config/kitty/read_config.py` to new kitten location
 
 ## v1.0.5r3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🐞 Fixed
 
+- Moved `read_config.py` kitten from `~/.config/kitty/` to `~/.config/kitty/kitty-control/`
+
 ## v1.0.5r3
 
 ### ⚡️ Added

--- a/install
+++ b/install
@@ -156,6 +156,11 @@ install_config() {
   [ -f ${HOME}/.config/kitty/read_config.py ] && {
     rm -f ${HOME}/.config/kitty/read_config.py
   }
+  # Link to the new location of the kitten
+  [ -f ${HOME}/.config/kitty/kitty-control/read_config.py ] && {
+    ln -s ${HOME}/.config/kitty/kitty-control/read_config.py \
+          ${DEST}/read_config.py
+  }
 }
 
 pathadd() {

--- a/install
+++ b/install
@@ -152,11 +152,9 @@ install_config() {
   else
     cp -a "${SCRIPT_PATH}"/config ${DEST}/kitty-control
   fi
+  # Delete the old location of the kitten
   [ -f ${HOME}/.config/kitty/read_config.py ] && {
-    [ -f ${DEST}/kitty-control/read_config.py ] || {
-      ln -s ${HOME}/.config/kitty/read_config.py \
-            ${DEST}/kitty-control/read_config.py
-    }
+    rm -f ${HOME}/.config/kitty/read_config.py
   }
 }
 
@@ -205,8 +203,12 @@ cp "${SCRIPT_PATH}"/kitty-control ${HOME}/.local/bin/kitty-control
 chmod 755 ${HOME}/.local/bin/kitty-control
 
 [ -d ${HOME}/.config/kitty ] || mkdir -p ${HOME}/.config/kitty
-cp "${SCRIPT_PATH}"/kitten/read_config.py ${HOME}/.config/kitty
-chmod 644 ${HOME}/.config/kitty/read_config.py
+[ -d ${HOME}/.config/kitty/kitty-control ] || {
+  mkdir -p ${HOME}/.config/kitty/kitty-control
+}
+rm -f ${HOME}/.config/kitty/kitty-control/read_config.py
+cp "${SCRIPT_PATH}"/kitten/read_config.py ${HOME}/.config/kitty/kitty-control
+chmod 644 ${HOME}/.config/kitty/kitty-control/read_config.py
 
 [ -f ${HOME}/.config/kitty/diff.conf ] || {
   cp "${SCRIPT_PATH}"/config/diff.conf ${HOME}/.config/kitty/diff.conf
@@ -217,8 +219,16 @@ install_config "${HOME}/.config/kitty"
 [ "${KITTY_CONFIG_DIRECTORY}" ] && {
   [ "${KITTY_CONFIG_DIRECTORY}" == "${HOME}/.config/kitty" ] || {
     [ -d "${KITTY_CONFIG_DIRECTORY}" ] && {
-      cp "${SCRIPT_PATH}"/kitten/read_config.py ${KITTY_CONFIG_DIRECTORY}
-      chmod 644 ${KITTY_CONFIG_DIRECTORY}/read_config.py
+      [ -f ${KITTY_CONFIG_DIRECTORY}/read_config.py ] && {
+        rm -f ${KITTY_CONFIG_DIRECTORY}/read_config.py
+      }
+      [ -d ${KITTY_CONFIG_DIRECTORY}/kitty-control ] || {
+        mkdir -p ${KITTY_CONFIG_DIRECTORY}/kitty-control
+      }
+      rm -f ${KITTY_CONFIG_DIRECTORY}/kitty-control/read_config.py
+      cp "${SCRIPT_PATH}"/kitten/read_config.py \
+          ${KITTY_CONFIG_DIRECTORY}/kitty-control
+      chmod 644 ${KITTY_CONFIG_DIRECTORY}/kitty-control/read_config.py
       [ -f ${KITTY_CONFIG_DIRECTORY}/diff.conf ] || {
         cp "${SCRIPT_PATH}"/config/diff.conf \
             ${KITTY_CONFIG_DIRECTORY}/diff.conf

--- a/kitten/read_config.py
+++ b/kitten/read_config.py
@@ -1,6 +1,6 @@
 # read_config.py - load the specified Kitty configuration
 #
-# usage: kitty @ kitten read_config.py /path/to/kitty.conf
+# usage: kitty @ kitten kitty-control/read_config.py /path/to/kitty.conf
 #
 # Author: Ronald Joe Record <ronaldrecord@gmail.com>
 # Date: written February 2024

--- a/kitty-control
+++ b/kitty-control
@@ -858,9 +858,9 @@ load_config_file() {
       prompt_continue
     }
   else
-    kitty @ ${SOCKET} kitten read_config.py "${cfgfile}"
+    kitty @ ${SOCKET} kitten kitty-control/read_config.py "${cfgfile}"
     [ "${debug}" ] && {
-      printf "\nDEBUG: kitty @ ${SOCKET} kitten read_config.py ${cfgfile}"
+      printf "\nDEBUG: kitty @ ${SOCKET} kitten kitty-control/read_config.py ${cfgfile}"
       prompt_continue
     }
   fi

--- a/uninstall
+++ b/uninstall
@@ -6,7 +6,6 @@ DIFFCONF="${HOME}/.config/kitty/diff.conf"
 DIRDCONF="${KITTY_CONFIG_DIRECTORY}/diff.conf"
 
 rm -f ${HOME}/.local/bin/kitty-control
-rm -f ${HOME}/.config/kitty/read_config.py
 rm -rf ${HOME}/.config/kitty/kitty-control
 [ -f ${DIFFCONF} ] && {
   grep kitty-control ${DIFFCONF} | grep example >/dev/null && {
@@ -16,7 +15,6 @@ rm -rf ${HOME}/.config/kitty/kitty-control
 [ "${KITTY_CONFIG_DIRECTORY}" ] && {
   [ "${KITTY_CONFIG_DIRECTORY}" == "${HOME}/.config/kitty" ] || {
     [ -d "${KITTY_CONFIG_DIRECTORY}" ] && {
-      rm -f ${KITTY_CONFIG_DIRECTORY}/read_config.py
       rm -rf ${KITTY_CONFIG_DIRECTORY}/kitty-control
       [ -f ${DIRDCONF} ] && {
         grep kitty-control ${DIRDCONF} | grep example >/dev/null && {

--- a/uninstall
+++ b/uninstall
@@ -6,6 +6,7 @@ DIFFCONF="${HOME}/.config/kitty/diff.conf"
 DIRDCONF="${KITTY_CONFIG_DIRECTORY}/diff.conf"
 
 rm -f ${HOME}/.local/bin/kitty-control
+rm -f ${HOME}/.config/kitty/read_config.py
 rm -rf ${HOME}/.config/kitty/kitty-control
 [ -f ${DIFFCONF} ] && {
   grep kitty-control ${DIFFCONF} | grep example >/dev/null && {
@@ -15,6 +16,7 @@ rm -rf ${HOME}/.config/kitty/kitty-control
 [ "${KITTY_CONFIG_DIRECTORY}" ] && {
   [ "${KITTY_CONFIG_DIRECTORY}" == "${HOME}/.config/kitty" ] || {
     [ -d "${KITTY_CONFIG_DIRECTORY}" ] && {
+      rm -f ${KITTY_CONFIG_DIRECTORY}/read_config.py
       rm -rf ${KITTY_CONFIG_DIRECTORY}/kitty-control
       [ -f ${DIRDCONF} ] && {
         grep kitty-control ${DIRDCONF} | grep example >/dev/null && {


### PR DESCRIPTION
To avoid any conflict with other 3rd party kittens, move `~/.config/kitty/read_config.py` to `~/.config/kitty/kitty-control/read_config.py`